### PR TITLE
明治の開始は6年からとする

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,7 @@ echo $wareki->getDay() // 1
 ```
 composer require iwahara/era-conveter
 ```
+
+## 注意
+
+明治5年までは太陰暦使用していたので変換対象外としてます（そのうち対応したい）。

--- a/src/Wareki/Meiji.php
+++ b/src/Wareki/Meiji.php
@@ -65,17 +65,17 @@ class Meiji implements WarekiInterface
      */
     private function checkFrom(int $year, int $month, int $day): bool
     {
-        //明治元年は9月8日から
+        //明治は6年1月1日から(太陽暦を採用したのがこの年からなので)
 
-        if ($year < 1) {
+        if ($year < 6) {
             return false;
         }
 
-        if ($year === 1 && $month < 9) {
+        if ($year === 1 && $month < 1) {
             return false;
         }
 
-        if ($year === 1 && $month === 9 && $day < 8) {
+        if ($year === 1 && $month === 1 && $day < 1) {
             return false;
         }
 

--- a/tests/Wareki/MeijiTest.php
+++ b/tests/Wareki/MeijiTest.php
@@ -15,7 +15,7 @@ class MeijiTest extends TestCase
      */
     public function test_resolve_今から明治()
     {
-        $datetime = new DateTimeImmutable("1868-09-08 00:00:00");
+        $datetime = new DateTimeImmutable("1873-01-01 00:00:00");
         $reiwa = new Meiji($datetime);
         self::assertTrue($reiwa->resolve());
     }
@@ -23,9 +23,9 @@ class MeijiTest extends TestCase
     /**
      * @test
      */
-    public function test_resolve_まだ慶応()
+    public function test_resolve_まだ明治だけど太陰暦なので対象外()
     {
-        $datetime = new DateTimeImmutable("1868-09-07 00:00:00");
+        $datetime = new DateTimeImmutable("1872-12-31 00:00:00");
         $reiwa = new Meiji($datetime);
         self::assertFalse($reiwa->resolve());
     }


### PR DESCRIPTION
明治５年までは太陰太陽暦を使っていたため単純に変換できないため、いったん明治の開始は6年1月1日とする。